### PR TITLE
avoid an error caused by treating static initializer as no arguments …

### DIFF
--- a/src/MicroResolver/Internal/Meta.cs
+++ b/src/MicroResolver/Internal/Meta.cs
@@ -46,7 +46,7 @@ namespace MicroResolver.Internal
             var injectConstructors = this.TypeInfo.DeclaredConstructors.Where(x => x.GetCustomAttribute<InjectAttribute>(true) != null).ToArray();
             if (injectConstructors.Length == 0)
             {
-                var grouped = this.TypeInfo.DeclaredConstructors.GroupBy(x => x.GetParameters().Length).OrderByDescending(x => x.Key).FirstOrDefault();
+                var grouped = this.TypeInfo.DeclaredConstructors.Where(x => !x.IsStatic).GroupBy(x => x.GetParameters().Length).OrderByDescending(x => x.Key).FirstOrDefault();
                 if (grouped == null)
                 {
                     throw new MicroResolverException("Type does not found injectable constructor, type:" + type.Name);

--- a/tests/MicroResolver.Test/_Classes.cs
+++ b/tests/MicroResolver.Test/_Classes.cs
@@ -288,6 +288,8 @@ namespace MicroResolver.Test
 
     public class SecondService : ISecondService
     {
+        private static readonly int staticInitialzierRequiredField = 1;
+
         public SecondService()
         {
         }


### PR DESCRIPTION
An error occurrs in Register<TInterface, TImplementation> method
when TImplementation type
has only one default (no arguments) constructor,
has no Inject attributes
and has declared or generated static initializer
because static initializer is treated as no arguments constructor.

Please exclude static initializer.

Thank you.